### PR TITLE
Enhancements to to_json function

### DIFF
--- a/vincent/vega_template.html
+++ b/vincent/vega_template.html
@@ -12,6 +12,6 @@
 function parse(spec) {
   vg.parse.spec(spec, function(chart) { chart({el:"#vis"}).update(); });
 }
-parse("vega.json");
+parse("$path");
 </script>
 </html>


### PR DESCRIPTION
I made some modifications to the `to_json` function of the Vega object if you're interested.

Some enhancements:
- The HTML template has an optional filename.
- The path of the data file is now specified by the user. It seems like a reasonable use case where the user wants the data file in a separate directory with a unique name.
- Added tests.

Some issues discovered along the way:
- `vega_template.html` required the JSON file to be named `vega.json` to work.
- HTML file would only generate if `split_data` was True. This shouldn't be necessary.

Note that I used the mock library for testing, so running the unit tests now requires either mock or Python > 3.3 to be installed.

Comments are welcome.
