### PR TITLE
BUG: mock imports weren't doing anything

### DIFF
--- a/tests/test_vincent.py
+++ b/tests/test_vincent.py
@@ -10,13 +10,6 @@ import vincent
 import nose.tools as nt
 import os.path as path
 
-try:
-    import unittest.mock as mock
-    assert mock
-except ImportError:
-    # Requires mock library if version < 3.3
-    import mock
-
 
 # Location of test data files.
 data_dir = path.join(path.dirname(path.abspath(__file__)), 'data')


### PR DESCRIPTION
These import statements weren't actually doing anything. The goal was to allow unit tests to run in Python 3.3 without installing the mock library, since it's included in the standard library, but this didn't actually work.

Since these are pretty minor, I'll go ahead and pull them in.
