### PR TITLE
BUG: Missing the variable 'path' in the shapefile mapping example.

### DIFF
--- a/examples/vincent_shapefile_mapping.py
+++ b/examples/vincent_shapefile_mapping.py
@@ -7,6 +7,8 @@ conversion with the Ogre web tool: http://ogre.adc4gis.com/
 
 import vincent
 
+path = r'vega.json'
+
 #Add Oceans
 vis = vincent.Map(width=1200, height=800)
 vis.geo_data(scale=200, spatial_convert=True, ocean=r'data/ne_110m_ocean.zip')


### PR DESCRIPTION
Hi,

Just test the file `examples/vincent_shapefile_mapping.py`. Missing the `path` variable.

Best regards,
Damien
