### PR TITLE
Make find_iter take an iterable.

### DIFF
--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -553,8 +553,8 @@ class TestData(object):
             nt.assert_list_equal(truthy[stacker['ref']], stack.values)
 
     def test_from_iter(self):
-        """Test data from single iter"""
-        test = Data.from_iter([10, 20, 30])
+        """Test data from single iterable"""
+        test = Data.from_iter(iter([10, 20, 30]))
         test1 = Data.from_iter((10, 20, 30))
         values = [{'x': 0, 'y': 10}, {'x': 1, 'y': 20}, {'x': 2, 'y': 30}]
         nt.assert_list_equal(test.values, values)

--- a/vincent/vega.py
+++ b/vincent/vega.py
@@ -827,13 +827,14 @@ class Data(GrammarClass):
 
     @classmethod
     def from_iter(cls, data, name=None):
-        """Convenience method for loading data from a single list. Defaults
-        to numerical indexing for x-axis.
+        """Convenience method for loading data from an iterable.
+
+        Defaults to numerical indexing for x-axis.
 
         Parameters
         ----------
-        data: list
-            List of data
+        data: iterable
+            An iterable of data
         name: string, default None
             Name of the data set. If None (default), the name will be set to
             ``'table'``.
@@ -841,8 +842,7 @@ class Data(GrammarClass):
         """
         if not name:
             name = 'table'
-        values = [{"x": x, "y": y}
-                  for x, y in zip(range(len(data)), data)]
+        values = [{"x": x, "y": y} for x, y in enumerate(data)]
         return cls(name, values=values)
 
     @classmethod


### PR DESCRIPTION
Hey.

So `find_iter` was relying on its thing being a sequence.

I haven't taken a close look at the rest of the code in the area here but I see that it could still use some refactoring -- I think IMHO you might want to consider taking an iterable as the canonical expected type, and then implement everything else on top of that (some of these seem unnecessary to me like `from_dict` but either way, `from_dict` would just be `return cls.from_iter(data.iteritems())` or if you chose to just make `__init__` expect an iterable...)

Either way, there's a lot of copying going on as a result of not passing around iterables, which might be a problem for people with large datasets.
