### PR TITLE
Allow both unicode and str in @grammar checks under Python2

### DIFF
--- a/tests/test_unicode_literals.py
+++ b/tests/test_unicode_literals.py
@@ -1,0 +1,14 @@
+  # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from vincent.charts import Bar
+
+def test_unicode_axes():
+    """Verify that python2.7 will allow arbitrary unicode strings
+       in the same way python 3.2/3.3 does.
+       We use unicode_literals __future__ to make this test cross platform
+       without using version switches,
+       """
+    bar = Bar([1, 2, 3])
+    bar.axis_titles(x="老特洛伊呗", y="ZAŻÓŁĆ GĘŚLĄ JAŹŃ")
+    ### XXX: if this proves to be correct fix, we should test more methods here

--- a/vincent/_compat.py
+++ b/vincent/_compat.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Compat: Minimal, required compatibility layer for py2/py3
+"""
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+
+if not PY2:
+    str_types = (str, )
+else:
+    str_types = (unicode, str)

--- a/vincent/axes.py
+++ b/vincent/axes.py
@@ -6,6 +6,8 @@ Axes: Classes for defining Vega axis properties
 """
 from .core import grammar, GrammarClass
 from .properties import PropertySet
+from ._compat import str_types
+
 
 
 class AxisProperties(GrammarClass):
@@ -38,13 +40,13 @@ class Axis(GrammarClass):
     Axes are visual cues that the viewer uses to interpret the marks
     representing the data itself.
     """
-    @grammar(str)
+    @grammar(str_types)
     def type(value):
         """string : Type of axis - ``'x'`` or ``'y'``"""
         if value not in ('x', 'y'):
             raise ValueError('Axis.type must be "x" or "y"')
 
-    @grammar(str)
+    @grammar(str_types)
     def title(value):
         """string: Axis title"""
 
@@ -56,18 +58,18 @@ class Axis(GrammarClass):
     def grid(value):
         """bool: If True, gridlines are created"""
 
-    @grammar(str)
+    @grammar(str_types)
     def scale(value):
         """string : Name of scale used for axis"""
 
-    @grammar(str)
+    @grammar(str_types)
     def orient(value):
         """string : Orientation of the axis
 
         Should be one of ``'top'``, ``'bottom'``, ``'left'``, or ``'right'``.
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def format(value):
         """string : Formatting to use for axis labels
 

--- a/vincent/core.py
+++ b/vincent/core.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     np = None
 
+from ._compat import str_types
+
 #TODO: Keep local?
 d3_js_url = "http://d3js.org/d3.v3.min.js"
 vega_js_url = 'http://trifacta.github.com/vega/vega.js'
@@ -30,7 +32,7 @@ def initialize_notebook():
         from IPython.core.display import display, Javascript
     except ImportError:
         print('IPython Notebook could not be loaded.')
-    
+
     display(Javascript('''$.getScript("%s", function() {
         $.getScript("%s", function() {
             $([IPython.events]).trigger("vega_loaded.vincent");
@@ -72,7 +74,7 @@ class KeyedList(list):
         return keys
 
     def __getitem__(self, key):
-        if isinstance(key, str):
+        if isinstance(key, str_types):
             keys = self.get_keys()
             if key not in keys:
                 raise KeyError(' "{0}" is an invalid key'.format(key))
@@ -82,7 +84,7 @@ class KeyedList(list):
             return list.__getitem__(self, key)
 
     def __delitem__(self, key):
-        if isinstance(key, str):
+        if isinstance(key, str_types):
             keys = self.get_keys()
             if key not in keys:
                 raise KeyError(' "{0}" is an invalid key'.format(key))
@@ -92,7 +94,7 @@ class KeyedList(list):
             return list.__delitem__(self, key)
 
     def __setitem__(self, key, value):
-        if isinstance(key, str):
+        if isinstance(key, str_types):
             if not hasattr(value, self.attr_name):
                 raise ValidationError(
                     'object must have ' + self.attr_name + ' attribute')
@@ -172,7 +174,7 @@ def grammar(grammar_type=None, grammar_name=None):
             else:
                 return grammar_creator(validator, validator.__name__)
         return grammar_dec
-    elif isinstance(grammar_name, str):
+    elif isinstance(grammar_name, str_types):
         # If grammar_name is a string, use that name and return another
         # decorator.
         def grammar_dec(validator):

--- a/vincent/data.py
+++ b/vincent/data.py
@@ -8,6 +8,7 @@ from __future__ import (print_function, division)
 import time
 import copy
 from .core import _assert_is_type, ValidationError, grammar, GrammarClass, LoadError
+from ._compat import str_types
 
 try:
     import pandas as pd
@@ -43,14 +44,14 @@ class Data(GrammarClass):
         super(self.__class__, self).__init__(**kwargs)
         self.name = name if name else 'table'
 
-    @grammar(str)
+    @grammar(str_types)
     def name(value):
         """string : Name of the data
 
         This is used by other components (``Mark``, etc.) for reference.
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def url(value):
         """string : URL from which to load the data
 
@@ -89,7 +90,7 @@ class Data(GrammarClass):
         for row in value:
             _assert_is_type('values row', row, (float, int, dict))
 
-    @grammar(str)
+    @grammar(str_types)
     def source(value):
         """string : ``name`` field of another data set
 
@@ -126,7 +127,7 @@ class Data(GrammarClass):
         This is used by the ``from_pandas`` and ``from_numpy`` functions to
         convert data to JSON-serializable types when loading.
         """
-        if isinstance(obj, str):
+        if isinstance(obj, str_types):
             return obj
         elif hasattr(obj, 'timetuple'):
             return int(time.mktime(obj.timetuple())) * 1000

--- a/vincent/legends.py
+++ b/vincent/legends.py
@@ -8,6 +8,7 @@ from __future__ import (print_function, division)
 from .core import (initialize_notebook, _assert_is_type, ValidationError,
                   KeyedList, grammar, GrammarClass, LoadError)
 from .values import ValueRef
+from ._compat import str_types
 
 
 class LegendProperties(GrammarClass):
@@ -47,23 +48,23 @@ class Legend(GrammarClass):
 
     """
 
-    @grammar(str)
+    @grammar(str_types)
     def size(value):
         """The name of the scale that determines an item's size"""
 
-    @grammar(str)
+    @grammar(str_types)
     def shape(value):
         """The name of the scale that determines an item's shape"""
 
-    @grammar(str)
+    @grammar(str_types)
     def fill(value):
         """The name of the scale that determines an item's fill color"""
 
-    @grammar(str)
+    @grammar(str_types)
     def stroke(value):
         """The name of the scale that determine's stroke color"""
 
-    @grammar(str)
+    @grammar(str_types)
     def orient(value):
         """The orientation of the legend.
 
@@ -77,11 +78,11 @@ class Legend(GrammarClass):
     def offset(value):
         """Pixel offset from figure"""
 
-    @grammar(str)
+    @grammar(str_types)
     def title(value):
         """The Legend title"""
 
-    @grammar(str)
+    @grammar(str_types)
     def format(value):
         """Optional formatting pattern for legend labels.
 

--- a/vincent/marks.py
+++ b/vincent/marks.py
@@ -7,6 +7,7 @@ Marks: Classes to define Vega Marks
 from .core import grammar, GrammarClass, KeyedList
 from .values import ValueRef
 from .properties import PropertySet
+from ._compat import str_types
 
 
 class MarkProperties(GrammarClass):
@@ -44,7 +45,7 @@ class MarkProperties(GrammarClass):
 class MarkRef(GrammarClass):
     """Definitions for Mark source data
     """
-    @grammar(str)
+    @grammar(str_types)
     def data(value):
         """string : Name of the source `Data`"""
 
@@ -63,15 +64,15 @@ class Mark(GrammarClass):
     _valid_type_values = ['rect', 'symbol', 'path', 'arc', 'area', 'line',
                           'image', 'text', 'group']
 
-    @grammar(str)
+    @grammar(str_types)
     def name(value):
         """string : Optional unique name for mark"""
 
-    @grammar(str)
+    @grammar(str_types)
     def description(value):
         """string : Optional description for mark"""
 
-    @grammar(str)
+    @grammar(str_types)
     def type(value):
         """string : Type of mark
 
@@ -96,7 +97,7 @@ class Mark(GrammarClass):
     def properties(value):
         """MarkProperties : Mark property set definitions"""
 
-    @grammar(str)
+    @grammar(str_types)
     def key(value):
         """string : Field to use for data binding
 
@@ -110,7 +111,7 @@ class Mark(GrammarClass):
         """ValueRef, number : Transitional delay in milliseconds.
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def ease(value):
         """string : Type of transition easing
 

--- a/vincent/properties.py
+++ b/vincent/properties.py
@@ -7,6 +7,7 @@ PropertySet: Definition of properties for ``Mark`` objects and labels of ``Axis`
 
 from .core import _assert_is_type, grammar, GrammarClass
 from .values import ValueRef
+from ._compat import str_types
 
 
 class PropertySet(GrammarClass):
@@ -81,7 +82,7 @@ class PropertySet(GrammarClass):
         large number of valid values.
         """
         if value.value:
-            _assert_is_type('fill.value', value.value, str)
+            _assert_is_type('fill.value', value.value, str_types)
 
     @grammar(grammar_type=ValueRef, grammar_name='fillOpacity')
     def fill_opacity(value):
@@ -150,7 +151,7 @@ class PropertySet(GrammarClass):
         ``'triangle-down'``. Only used if ``type`` is ``'symbol'``.
         """
         if value.value:
-            _assert_is_type('shape.value', value.value, str)
+            _assert_is_type('shape.value', value.value, str_types)
             if value.value not in PropertySet._valid_shapes:
                 raise ValueError(value.value + ' is not a valid shape')
 
@@ -162,7 +163,7 @@ class PropertySet(GrammarClass):
         path is taken from the data.
         """
         if value.value:
-            _assert_is_type('path.value', value.value, str)
+            _assert_is_type('path.value', value.value, str_types)
 
     @grammar(grammar_type=ValueRef, grammar_name='innerRadius')
     def inner_radius(value):

--- a/vincent/scales.py
+++ b/vincent/scales.py
@@ -5,7 +5,7 @@ Scales: Classes to define Vega scales
 
 """
 from .core import grammar, GrammarClass
-
+from ._compat import str_types
 
 class DataRef(GrammarClass):
     """Definitions for how data is referenced by scales
@@ -13,11 +13,11 @@ class DataRef(GrammarClass):
     Data can be referenced in multiple ways, and sometimes it makes sense to
     reference multiple data fields at once.
     """
-    @grammar(str)
+    @grammar(str_types)
     def data(value):
         """string : Name of data-set containing the domain values"""
 
-    @grammar((list, str))
+    @grammar((list,) + str_types)
     def field(value):
         """string or list of strings : Reference to desired data field(s)
 
@@ -33,14 +33,14 @@ class Scale(GrammarClass):
     as numbers, time stamps, etc.) to a visual space (length of a line,
     height of a bar, etc.), for both independent and dependent variables.
     """
-    @grammar(str)
+    @grammar(str_types)
     def name(value):
         """string : Unique name for the scale
 
         This is used for referencing by other components (mainly ``Mark``).
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def type(value):
         """string : Type of the scale
 
@@ -80,7 +80,7 @@ class Scale(GrammarClass):
         the maximum of the ``domain`` property.
         """
 
-    @grammar((list, str))
+    @grammar((list,) + str_types)
     def range(value):
         """list or string : Range of the scale
 
@@ -139,7 +139,7 @@ class Scale(GrammarClass):
         Ignored for ordinal scales.
         """
 
-    @grammar((bool, str))
+    @grammar((bool,) + str_types)
     def nice(value):
         """boolean or string : scale the domain to a more human-friendly set
 

--- a/vincent/transforms.py
+++ b/vincent/transforms.py
@@ -6,7 +6,7 @@ Transforms: Vincent Data Class for Vega Transform types
 """
 from __future__ import (print_function, division)
 from .core import _assert_is_type, ValidationError, grammar, GrammarClass, LoadError
-
+from ._compat import str_types
 
 class Transform(GrammarClass):
     """Container to Transforma metrics
@@ -23,7 +23,7 @@ class Transform(GrammarClass):
 
     """
 
-    @grammar(str)
+    @grammar(str_types)
     def type(value):
         """string: property name in which to store the computed transform value.
 
@@ -50,7 +50,7 @@ class Transform(GrammarClass):
 
         """
 
-    @grammar(grammar_type=str, grammar_name='from')
+    @grammar(grammar_type=str_types, grammar_name='from')
     def from_(value):
         """str: The name of the object to copy values from
 
@@ -76,14 +76,14 @@ class Transform(GrammarClass):
         Only used if ``type`` is ``facet``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def sort(value):
         """string: Optional for sorting facet values
 
         Only used if ``type`` is ``facet``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def test(value):
         """string: A string containing a javascript filtering expression.
 
@@ -92,7 +92,7 @@ class Transform(GrammarClass):
         Only used if ``type`` is ``filter``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def field(value):
         """string: Property name to store computed formula value.
 
@@ -101,7 +101,7 @@ class Transform(GrammarClass):
         See: https://github.com/trifacta/vega/wiki/Data-Transforms#-formula
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def expr(value):
         """string: Javascript expression of a formula, referencing the data as d.
 
@@ -110,7 +110,7 @@ class Transform(GrammarClass):
         See: https://github.com/trifacta/vega/wiki/Data-Transforms#-formula
         """
 
-    @grammar((str, list))
+    @grammar(str_types + (list,))
     def by(value):
         """str, list: a field or list of fields to sort. Can prepend with - to
         sort descending.
@@ -118,7 +118,7 @@ class Transform(GrammarClass):
         Only used if ``type`` is ``sort``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def value(value):
         """str: Field for which to compute statistics.
 
@@ -132,28 +132,28 @@ class Transform(GrammarClass):
         Only used if ``type`` is stats``
         """
 
-    @grammar(grammar_type=str, grammar_name='with')
+    @grammar(grammar_type=str_types, grammar_name='with')
     def with_(value):
         """string: Name of dataset to zip to current dataset
 
         Only used if ``type`` is ``zip``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def key(value):
         """string: Primary dataset field to match to secondary data
 
         Only used if ``type`` is ``zip``
         """
 
-    @grammar(grammar_type=str, grammar_name='withKey')
+    @grammar(grammar_type=str_types, grammar_name='withKey')
     def with_key(value):
         """string: Field in secondary dataset to match to primary
 
         Only used if ``type`` is ``zip``
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def links(value):
         """string: Name of link (edge) data set.
 
@@ -174,21 +174,21 @@ class Transform(GrammarClass):
         To be used with ``force`` types
         """
 
-    @grammar((int, str))
+    @grammar((int,) + str_types)
     def charge(value):
         """int or string: Strength of the charge each node exerts.
 
         To be used with ``force`` types
         """
 
-    @grammar(grammar_type=(int, str), grammar_name='linkDistance')
+    @grammar(grammar_type=(int,) + str_types, grammar_name='linkDistance')
     def link_distance(value):
         """int or string: Determines lenght of the edges, in pixels.
 
         To be used with ``force`` types
         """
 
-    @grammar(grammar_type=(int, str), grammar_name='linkStrength')
+    @grammar(grammar_type=(int,) + str_types, grammar_name='linkStrength')
     def link_strength(value):
         """int or string: Determines the tension of the edges.
 
@@ -223,7 +223,7 @@ class Transform(GrammarClass):
         To be used with ``force`` types
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def point(value):
         """string: Data field determining the points at which to stack. When stacked
         vertically, these are the x-coords.
@@ -231,14 +231,14 @@ class Transform(GrammarClass):
         To be used with ``stack`` types
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def height(value):
         """string: Data field determining thickness, or height of stacks.
 
         To be used with ``stack`` types
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def offset(value):
         """string: Baseline offset style. Must be one of the following:
 
@@ -250,7 +250,7 @@ class Transform(GrammarClass):
         if value not in offsets:
             raise ValueError('offset must be one of {0}'.format(offsets))
 
-    @grammar(str)
+    @grammar(str_types)
     def order(value):
         """str: The sort order for stack layers. Must be one of the following:
 

--- a/vincent/values.py
+++ b/vincent/values.py
@@ -5,7 +5,7 @@ ValueRef: Generally used in a PropertySet class to define a set of values within
 
 """
 from .core import grammar, GrammarClass
-
+from ._compat import str_types
 
 class ValueRef(GrammarClass):
     """Container for the value-referencing properties of marks
@@ -19,14 +19,14 @@ class ValueRef(GrammarClass):
     ValueRefs can reference numbers, strings, or arbitrary objects,
     depending on their use.
     """
-    @grammar((str, int, float))
+    @grammar(str_types + (int, float))
     def value(value):
         """int, float, or string : used for constant values
 
         This is ignored if the ``field`` property is defined.
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def field(value):
         """string : reference to a field of the data in dot-notation
 
@@ -37,7 +37,7 @@ class ValueRef(GrammarClass):
         element is always `data` regardless of the name of the data.
         """
 
-    @grammar(str)
+    @grammar(str_types)
     def scale(value):
         """string : reference to the name of a ``Scale``
 

--- a/vincent/visualization.py
+++ b/vincent/visualization.py
@@ -14,6 +14,7 @@ from .marks import Mark
 from .axes import Axis
 from .legends import Legend
 from .colors import brews
+from ._compat import str_types
 
 
 class Visualization(GrammarClass):
@@ -46,7 +47,7 @@ class Visualization(GrammarClass):
         if not self.legends:
             self.legends = []
 
-    @grammar(str)
+    @grammar(str_types)
     def name(value):
         """string : Name of the visualization (optional)
         """
@@ -86,7 +87,7 @@ class Visualization(GrammarClass):
             if v < 0:
                 raise ValueError('viewport dimensions cannot be negative')
 
-    @grammar((int, dict, str))
+    @grammar((int, dict,) + str_types)
     def padding(value):
         """int or dict : Padding around visualization
 


### PR DESCRIPTION
Allowing only `str` can cause validation errors in programs that decode
everything to `unicode` as soon as possible OR have unicode_literals
**future** turned on.

Since most (all?) of the values checked against `str` end up in JSON
lists/dictionaries anyway, it's seems unreasonable to reject them in
Python.

All tests pass under py27, py32 & py33

I'm only starting with vincent, if I botched something up just let me know, I'll try to fix it :)
