### PR TITLE
Fix iPython Notebook display() to also render Maps

### DIFF
--- a/vincent/core.py
+++ b/vincent/core.py
@@ -23,6 +23,8 @@ from ._compat import str_types
 
 #TODO: Keep local?
 d3_js_url = "http://d3js.org/d3.v3.min.js"
+d3_geo_projection_js_url = "http://d3js.org/d3.geo.projection.v0.min.js"
+topojson_js_url = "http://d3js.org/topojson.v1.min.js"
 vega_js_url = 'http://trifacta.github.com/vega/vega.js'
 
 
@@ -35,9 +37,13 @@ def initialize_notebook():
 
     display(Javascript('''$.getScript("%s", function() {
         $.getScript("%s", function() {
-            $([IPython.events]).trigger("vega_loaded.vincent");
+            $.getScript("%s", function() {
+                $.getScript("%s", function() {
+                    $([IPython.events]).trigger("vega_loaded.vincent");
+                })
+            })
         })
-    });''' % (d3_js_url, vega_js_url)))
+    });''' % (d3_js_url, d3_geo_projection_js_url, topojson_js_url, vega_js_url)))
 
 
 def _assert_is_type(name, value, value_type):


### PR DESCRIPTION
First of all, thank you very much for this project. It is precisely what I need at the moment

Currently the [Map example](https://vincent.readthedocs.org/en/latest/charts_library.html#simple-map) does not work when executed within an iPython Notebook.

This is because the TopoJson and D3 Geo Projection javascript libraries aren't loaded when initialize_notebook() is called. (see [Vega Template](vega_template.html))

After I made these changes the maps worked for me. Obviously the initial download now takes a bit longer. The other option is to make the Geo libraries optional when calling initialize_notebook()?
