### PR TITLE
Fix 'd3 is not defined' problem as seen in #64

### DIFF
--- a/vincent/core.py
+++ b/vincent/core.py
@@ -25,7 +25,7 @@ from ._compat import str_types
 require_js = '''
     require.config({paths: {d3: "http://d3js.org/d3.v3.min"}});
     require(["d3"], function(d3) {
-      window.d3 = d3;
+        console.log(d3.version);
     });
     '''
 d3_geo_projection_js_url = "http://d3js.org/d3.geo.projection.v0.min.js"


### PR DESCRIPTION
This change resolves the issue for me in testing - the cause appears to be a recent change in D3 itself, but fortunately @mbostock has also provided the fix used here as well: 

http://git.io/fiNrQA

Relevant comment in discussion of #64:

http://git.io/RdKJZA
