### PR TITLE
Fix for 'TopoJSON library not loading in IPython notebook' in Issue #93

### DIFF
--- a/vincent/core.py
+++ b/vincent/core.py
@@ -40,6 +40,12 @@ def initialize_notebook():
           {0}
         }});
     }};
+    if (window['topojson'] === undefined) {{
+        require.config({{ paths: {{topojson: "http://d3js.org/topojson.v1.min"}} }});
+        require(["topojson"], function(topojson) {{
+          window.topojson = topojson;
+        }});
+    }};
     '''
     d3_geo_projection_js_url = "http://d3js.org/d3.geo.projection.v0.min.js"
     d3_layout_cloud_js_url = ("http://wrobstory.github.io/d3-cloud/"


### PR DESCRIPTION
This fixes https://github.com/wrobstory/vincent/issues/93

I used the same pattern that was used to load d3.js. I noticed the recent issue where d3 was failing to load and used the same pattern in vincent/core.py: https://github.com/wrobstory/vincent/pull/90 and I think the same 
