### PR TITLE
Load external JS libraries using the current protocol

### DIFF
--- a/tests/vega_template.html
+++ b/tests/vega_template.html
@@ -1,10 +1,10 @@
 <html>
   <head>
     <title>Vega Scaffold</title>
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-    <script src="http://d3js.org/topojson.v1.min.js"></script>
-    <script src="http://d3js.org/d3.geo.projection.v0.min.js" charset="utf-8"></script>
-    <script src="http://trifacta.github.com/vega/vega.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js" charset="utf-8"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/0.2.9/d3.geo.projection.min.js" charset="utf-8"></script>
+    <script src="//wrobstory.github.io/vega/vega.v1.3.3.js"></script>
   </head>
   <body>
     <div id="vis"></div>

--- a/vega_template.html
+++ b/vega_template.html
@@ -1,10 +1,10 @@
 <html>
   <head>
     <title>Vega Scaffold</title>
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-    <script src="http://d3js.org/topojson.v1.min.js"></script>
-    <script src="http://d3js.org/d3.geo.projection.v0.min.js" charset="utf-8"></script>
-    <script src="http://trifacta.github.com/vega/vega.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js" charset="utf-8"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/0.2.9/d3.geo.projection.min.js" charset="utf-8"></script>
+    <script src="//wrobstory.github.io/vega/vega.v1.3.3.js"></script>
   </head>
   <body>
     <div id="vis"></div>

--- a/vincent/core.py
+++ b/vincent/core.py
@@ -34,7 +34,7 @@ def initialize_notebook():
     load_lib = """
                 function vct_load_lib(url, callback){
                       if(typeof d3 !== 'undefined' &&
-                         url === 'http://d3js.org/d3.v3.min.js'){
+                         url === '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js'){
                         callback()
                       }
                       var s = document.createElement('script');
@@ -52,11 +52,12 @@ def initialize_notebook():
                 );
                 """
     lib_urls = [
-        "'http://d3js.org/d3.v3.min.js'",
-        "'http://d3js.org/d3.geo.projection.v0.min.js'",
-        "'http://wrobstory.github.io/d3-cloud/d3.layout.cloud.js'",
-        "'http://wrobstory.github.io/vega/vega.v1.3.3.js'"
+        "'//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js'",
+        "'//cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/0.2.9/d3.geo.projection.min.js'",
+        "'//wrobstory.github.io/d3-cloud/d3.layout.cloud.js'",
+        "'//wrobstory.github.io/vega/vega.v1.3.3.js'"
     ]
+    print(lib_urls)
     get_lib = """vct_load_lib(%s, function(){
                   %s
                   });"""
@@ -77,8 +78,8 @@ def initialize_notebook():
                         window['topojson'] === undefined){
                         require.config(
                             {paths: {
-                              d3: 'http://d3js.org/d3.v3.min',
-                              topojson: 'http://d3js.org/topojson.v1.min'
+                              d3: '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min',
+                              topojson: '//cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min'
                               }
                             }
                           );

--- a/vincent/core.py
+++ b/vincent/core.py
@@ -57,7 +57,6 @@ def initialize_notebook():
         "'//wrobstory.github.io/d3-cloud/d3.layout.cloud.js'",
         "'//wrobstory.github.io/vega/vega.v1.3.3.js'"
     ]
-    print(lib_urls)
     get_lib = """vct_load_lib(%s, function(){
                   %s
                   });"""

--- a/vincent/vega_template.html
+++ b/vincent/vega_template.html
@@ -1,10 +1,10 @@
 <html>
   <head>
     <title>Vega Scaffold</title>
-    <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-    <script src="http://d3js.org/topojson.v1.min.js"></script>
-    <script src="http://d3js.org/d3.geo.projection.v0.min.js" charset="utf-8"></script>
-    <script src="http://trifacta.github.com/vega/vega.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.3/d3.min.js" charset="utf-8"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/topojson/1.6.9/topojson.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/0.2.9/d3.geo.projection.min.js" charset="utf-8"></script>
+    <script src="//wrobstory.github.io/vega/vega.v1.3.3.js"></script>
   </head>
   <body>
     <div id="vis"></div>


### PR DESCRIPTION
This fixes the issue of Vincent not working when the IPython notebook is on https.  This is the case when running a from a remote server.  Instead of using urls that start with 'http://' they just start with '//'.  The browser then uses the protocol currently in use.

This issue has been discussed previously in #64 which was closed with the intent of making a more comprehensive solution to how external JS files are loaded.  This current PR is more minor in scope in comparison.  The JS libraries are still loaded remotely, it just loads from http or https appropriately.

Some caveats:

1. The urls I am using all have specific versions of the external libraries.  I don't know if this is ideal or if the versions I picked (the latest) are compatible with all the features of Vincent.
2. My testing was pretty limited.  I was working on a problem with NetworkX in the IPython notebook with a remote server.  If there is a check list for a PR I'll be happy to be a better tester.