### PR TITLE
Fix dates not formatting correctly in bar charts

### DIFF
--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -200,8 +200,9 @@ class Bar(Chart):
         super(Bar, self).__init__(*args, **kwargs)
 
         # Scales
+        x_type = 'time' if self._is_datetime else 'linear'
         self.scales += [
-            Scale(name='x', type='ordinal', range='width', zero=False,
+            Scale(name='x', type=x_type, range='width', zero=False,
                   domain=DataRef(data='table', field='data.idx')),
             Scale(name='y', range='height', nice=True,
                   domain=DataRef(data='stats', field='sum')),


### PR DESCRIPTION
In bar charts, the scale does not determine whether the x-axis consists of datetime objects, and it converts all of the values to UNIX timestamps instead of nicely formatted dates. This fixes that.