### PR TITLE
Use time scale when index has type 'date' or 'datetime'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.4"
 before_install:
+  - sudo apt-get update
   - sudo apt-get install -qq gfortran libatlas-base-dev python-numpy
 install:
   - pip install ipython mock pandas flake8 --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -qq gfortran libatlas-base-dev python-numpy
 install:
-  - pip install ipython mock pandas flake8 --use-mirrors
+  - pip install ipython mock pandas flake8 jinja2 --use-mirrors
 script:
   - flake8 --exclude=colors.py,_compat.py vincent tests
   - nosetests

--- a/examples/stacked_area_examples.py
+++ b/examples/stacked_area_examples.py
@@ -22,31 +22,31 @@ vis.padding = {'top': 10, 'left': 50, 'bottom': 50, 'right': 100}
 
 data = Data.from_pandas(price)
 vis.data['table'] = data
-facets = Transform(type='facet', keys=['data.idx'])
-stats = Transform(type='stats', value='data.val')
+facets = Transform(type='facet', groupby=['idx'])
+stats = Transform(type='aggregate', value='val')
 stat_dat = Data(name='stats', source='table', transform=[facets, stats])
 vis.data['stats'] = stat_dat
 
 
 vis.scales['x'] = Scale(name='x', type='time', range='width',
-                        domain=DataRef(data='table', field="data.idx"))
+                        domain=DataRef(data='table', field="idx"))
 vis.scales['y'] = Scale(name='y', range='height', type='linear', nice=True,
                         domain=DataRef(data='stats', field="sum"))
 vis.scales['color'] = Scale(name='color', type='ordinal',
-                            domain=DataRef(data='table', field='data.col'),
+                            domain=DataRef(data='table', field='col'),
                             range='category20')
 vis.axes.extend([Axis(type='x', scale='x'),
                  Axis(type='y', scale='y')])
 
 
-facet = Transform(type='facet', keys=['data.col'])
-stack = Transform(type='stack', point='data.idx', height='data.val')
+facet = Transform(type='facet', groupby=['col'])
+stack = Transform(type='stack', point='idx', height='val')
 transform = MarkRef(data='table',transform=[facet, stack])
-enter_props = PropertySet(x=ValueRef(scale='x', field="data.idx"),
+enter_props = PropertySet(x=ValueRef(scale='x', field="idx"),
                           y=ValueRef(scale='y', field="y"),
                           interpolate=ValueRef(value='monotone'),
                           y2=ValueRef(field='y2', scale='y'),
-                          fill=ValueRef(scale='color', field='data.col'))
+                          fill=ValueRef(scale='color', field='col'))
 mark = Mark(type='group', from_=transform,
             marks=[Mark(type='area',
             properties=MarkProperties(enter=enter_props))])

--- a/examples/stacked_bar_examples.py
+++ b/examples/stacked_bar_examples.py
@@ -27,31 +27,31 @@ vis.padding = {'top': 10, 'left': 50, 'bottom': 50, 'right': 100}
 
 data = Data.from_pandas(df)
 vis.data['table'] = data
-facets = Transform(type='facet', keys=['data.idx'])
-stats = Transform(type='stats', value='data.val')
+facets = Transform(type='facet', groupby=['idx'])
+stats = Transform(type='aggregate', value='val')
 stat_dat = Data(name='stats', source='table', transform=[facets, stats])
 vis.data['stats'] = stat_dat
 
 
 vis.scales['x'] = Scale(name='x', type='ordinal', range='width',
-                        domain=DataRef(data='table', field="data.idx"))
+                        domain=DataRef(data='table', field="idx"))
 vis.scales['y'] = Scale(name='y', range='height', type='linear', nice=True,
                         domain=DataRef(data='stats', field="sum"))
 vis.scales['color'] = Scale(name='color', type='ordinal',
-                            domain=DataRef(data='table', field='data.col'),
+                            domain=DataRef(data='table', field='col'),
                             range='category20')
 vis.axes.extend([Axis(type='x', scale='x'),
                  Axis(type='y', scale='y')])
 
 
-facet = Transform(type='facet', keys=['data.col'])
-stack = Transform(type='stack', point='data.idx', height='data.val')
+facet = Transform(type='facet', groupby=['col'])
+stack = Transform(type='stack', point='idx', height='val')
 transform = MarkRef(data='table',transform=[facet, stack])
-enter_props = PropertySet(x=ValueRef(scale='x', field="data.idx"),
+enter_props = PropertySet(x=ValueRef(scale='x', field="idx"),
                           y=ValueRef(scale='y', field="y"),
                           width=ValueRef(scale='x', band=True, offset=-1),
                           y2=ValueRef(field='y2', scale='y'),
-                          fill=ValueRef(scale='color', field='data.col'))
+                          fill=ValueRef(scale='color', field='col'))
 mark = Mark(type='group', from_=transform,
             marks=[Mark(type='rect',
             properties=MarkProperties(enter=enter_props))])

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -104,15 +104,15 @@ class TestScatter(object):
 
         scatter = Scatter([1, 2, 3])
 
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'x',
                    'range': 'width',
                    'type': 'linear'},
-                  {'domain': {'data': 'table', 'field': 'data.val'},
+                  {'domain': {'data': 'table', 'field': 'val'},
                    'name': 'y',
                    'range': 'height',
                    'nice': True},
-                  {'domain': {'data': 'table', 'field': 'data.col'},
+                  {'domain': {'data': 'table', 'field': 'col'},
                    'name': 'color',
                    'range': 'category20',
                    'type': 'ordinal'}]
@@ -125,17 +125,17 @@ class TestScatter(object):
             'from': {
                 'data': 'table',
                 'transform': [
-                    {'keys': ['data.col'], 'type': 'facet'}
+                    {'keys': ['col'], 'type': 'facet'}
                 ]
             },
             'marks': [{
                 'type': 'symbol',
                 'properties': {
                     'enter': {
-                        'fill': {'field': 'data.col', 'scale': 'color'},
+                        'fill': {'field': 'col', 'scale': 'color'},
                         'size': {'value': 100},
-                        'x': {'field': 'data.idx', 'scale': 'x'},
-                        'y': {'field': 'data.val', 'scale': 'y'}}},
+                        'x': {'field': 'idx', 'scale': 'x'},
+                        'y': {'field': 'val', 'scale': 'y'}}},
             }]
         }]
 
@@ -148,15 +148,15 @@ class TestLine(object):
     def test_init(self):
         line = Line([1, 2, 3])
 
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'x',
                    'type': 'linear',
                    'range': 'width'},
-                  {'domain': {'data': 'table', 'field': 'data.val'},
+                  {'domain': {'data': 'table', 'field': 'val'},
                    'name': 'y',
                    'nice': True,
                    'range': 'height'},
-                  {'domain': {'data': 'table', 'field': 'data.col'},
+                  {'domain': {'data': 'table', 'field': 'col'},
                    'name': 'color',
                    'range': 'category20',
                    'type': 'ordinal'}]
@@ -169,17 +169,17 @@ class TestLine(object):
             'from': {
                 'data': 'table',
                 'transform': [
-                    {'keys': ['data.col'], 'type': 'facet'}
+                    {'keys': ['col'], 'type': 'facet'}
                 ]
             },
             'marks': [{
                 'type': 'line',
                 'properties': {
                     'enter': {
-                        'stroke': {'field': 'data.col', 'scale': 'color'},
+                        'stroke': {'field': 'col', 'scale': 'color'},
                         'strokeWidth': {'value': 2},
-                        'x': {'field': 'data.idx', 'scale': 'x'},
-                        'y': {'field': 'data.val', 'scale': 'y'}
+                        'x': {'field': 'idx', 'scale': 'x'},
+                        'y': {'field': 'val', 'scale': 'y'}
                     }
                 }
             }]
@@ -209,15 +209,15 @@ class TestArea(object):
             {'name': 'stats',
              'source': 'table',
              'transform': [
-                 {'type': 'facet', 'keys': ['data.idx']},
-                 {'type': 'stats', 'value': 'data.val'}]}
+                 {'type': 'facet', 'keys': ['idx']},
+                 {'type': 'stats', 'value': 'val'}]}
         ]
 
         for i, data in enumerate(datas):
             nt.assert_dict_equal(stacked_area.data[i].grammar(), data)
 
         # Test area grammar
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'x',
                    'range': 'width',
                    'zero': False,
@@ -226,7 +226,7 @@ class TestArea(object):
                    'name': 'y',
                    'nice': True,
                    'range': 'height'},
-                  {'domain': {'data': 'table', 'field': 'data.col'},
+                  {'domain': {'data': 'table', 'field': 'col'},
                    'name': 'color',
                    'range': 'category20',
                    'type': 'ordinal'}]
@@ -239,18 +239,18 @@ class TestArea(object):
             'from': {
                 'data': 'table',
                 'transform': [
-                    {'type': 'facet', 'keys': ['data.col']},
-                    {'type': 'stack', 'height': 'data.val',
-                     'point': 'data.idx'}]
+                    {'type': 'facet', 'keys': ['col']},
+                    {'type': 'stack', 'height': 'val',
+                     'point': 'idx'}]
             },
             'marks': [{
                 'type': 'area',
                 'properties': {
                     'enter': {
-                        'x': {'field': 'data.idx', 'scale': 'x'},
+                        'x': {'field': 'idx', 'scale': 'x'},
                         'y': {'field': 'y', 'scale': 'y'},
                         'y2': {'field': 'y2', 'scale': 'y'},
-                        'fill': {'field': 'data.col', 'scale': 'color'},
+                        'fill': {'field': 'col', 'scale': 'color'},
                         'interpolate': {'value': 'monotone'}
                     }
                 }
@@ -282,14 +282,14 @@ class TestBar(object):
             {'name': 'stats',
              'source': 'table',
              'transform': [
-                 {'type': 'facet', 'keys': ['data.idx']},
-                 {'type': 'stats', 'value': 'data.val'}]}
+                 {'type': 'facet', 'keys': ['idx']},
+                 {'type': 'stats', 'value': 'val'}]}
         ]
         for i, data in enumerate(datas):
             nt.assert_dict_equal(stacked_bar.data[i].grammar(), data)
 
         # Test bar grammar
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'x',
                    'range': 'width',
                    'zero': False,
@@ -298,7 +298,7 @@ class TestBar(object):
                    'name': 'y',
                    'nice': True,
                    'range': 'height'},
-                  {'domain': {'data': 'table', 'field': 'data.col'},
+                  {'domain': {'data': 'table', 'field': 'col'},
                    'name': 'color',
                    'range': 'category20',
                    'type': 'ordinal'}]
@@ -311,19 +311,19 @@ class TestBar(object):
             'from': {
                 'data': 'table',
                 'transform': [
-                    {'type': 'facet', 'keys': ['data.col']},
-                    {'type': 'stack', 'height': 'data.val',
-                     'point': 'data.idx'}]
+                    {'type': 'facet', 'keys': ['col']},
+                    {'type': 'stack', 'height': 'val',
+                     'point': 'idx'}]
             },
             'marks': [{
                 'type': 'rect',
                 'properties': {
                     'enter': {
-                        'x': {'field': 'data.idx', 'scale': 'x'},
+                        'x': {'field': 'idx', 'scale': 'x'},
                         'width': {'band': True, 'offset': -1, 'scale': 'x'},
                         'y': {'field': 'y', 'scale': 'y'},
                         'y2': {'field': 'y2', 'scale': 'y'},
-                        'fill': {'field': 'data.col', 'scale': 'color'}
+                        'fill': {'field': 'col', 'scale': 'color'}
                     }
                 }
             }]
@@ -361,16 +361,16 @@ class TestGroupedBar(object):
             nt.assert_dict_equal(group.data[i].grammar(), data)
 
         # Test grouped bar grammar
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'x',
                    'padding': 0.2,
                    'range': 'width',
                    'type': 'ordinal'},
-                  {'domain': {'data': 'table', 'field': 'data.val'},
+                  {'domain': {'data': 'table', 'field': 'val'},
                    'name': 'y',
                    'nice': True,
                    'range': 'height'},
-                  {'domain': {'data': 'table', 'field': 'data.col'},
+                  {'domain': {'data': 'table', 'field': 'col'},
                    'name': 'color',
                    'range': 'category20',
                    'type': 'ordinal'}]
@@ -382,16 +382,16 @@ class TestGroupedBar(object):
             'type': 'group',
             'from': {
                 'data': 'table',
-                'transform': [{'keys': ['data.idx'], 'type': 'facet'}]
+                'transform': [{'keys': ['idx'], 'type': 'facet'}]
             },
             'marks': [{
                 'type': 'rect',
                 'properties': {
                     'enter': {
-                        'fill': {'field': 'data.col', 'scale': 'color'},
+                        'fill': {'field': 'col', 'scale': 'color'},
                         'width': {'band': True, 'offset': -1, 'scale': 'pos'},
-                        'x': {'field': 'data.col', 'scale': 'pos'},
-                        'y': {'field': 'data.val', 'scale': 'y'},
+                        'x': {'field': 'col', 'scale': 'pos'},
+                        'y': {'field': 'val', 'scale': 'y'},
                         'y2': {'scale': 'y', 'value': 0}}
                 }
             }],
@@ -402,7 +402,7 @@ class TestGroupedBar(object):
                 }
             },
             'scales': [{
-                'domain': {'field': 'data.col'},
+                'domain': {'field': 'col'},
                 'name': 'pos',
                 'range': 'width',
                 'type': 'ordinal'
@@ -421,7 +421,7 @@ class TestPie(object):
         axes = []
 
         scales = [{
-            "domain": {"data": "table", "field": "data.idx"},
+            "domain": {"data": "table", "field": "idx"},
             "name": "color",
             "range": "category10",
             "type": "ordinal"
@@ -431,7 +431,7 @@ class TestPie(object):
             "type": "arc",
             "from": {
                 "data": "table",
-                "transform": [{"type": "pie", "value": "data.val"}]
+                "transform": [{"type": "pie", "value": "val"}]
             },
             "properties": {
                 "enter": {
@@ -442,7 +442,7 @@ class TestPie(object):
                     "outerRadius": {"value": 250},
                     "startAngle": {"field": "startAngle"},
                     "stroke": {"value": "white"},
-                    "fill": {"field": "data.idx", "scale": "color"}
+                    "fill": {"field": "idx", "scale": "color"}
                 }
             }
         }]
@@ -657,7 +657,7 @@ class TestWord(object):
 
         axes = []
 
-        scales = [{'domain': {'data': 'table', 'field': 'data.idx'},
+        scales = [{'domain': {'data': 'table', 'field': 'idx'},
                    'name': 'color',
                    'range': 'category10',
                    'type': 'ordinal'}]
@@ -670,10 +670,10 @@ class TestWord(object):
                     'align': {'value': 'center'},
                     'angle': {'field': 'angle'},
                     'baseline': {'value': 'middle'},
-                    'fill': {'field': 'data.idx', 'scale': 'color'},
+                    'fill': {'field': 'idx', 'scale': 'color'},
                     'font': {'field': 'font'},
                     'fontSize': {'field': 'fontSize'},
-                    'text': {'field': 'data.idx'},
+                    'text': {'field': 'idx'},
                     'x': {'field': 'x'},
                     'y': {'field': 'y'}
                 }

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -11,7 +11,8 @@ import nose.tools as nt
 from vincent.charts import (data_type, Chart, Bar, Scatter, Line, Area,
                             GroupedBar, Map, Pie, Word)
 
-nt.assert_equal.__self__.maxDiff = None                            
+nt.assert_equal.__self__.maxDiff = None
+
 
 def chart_runner(chart, scales, axes, marks):
     """Iterate through each chart element for check for contents"""
@@ -567,7 +568,7 @@ class TestMaps(object):
                           'as': ['value'],
                           'default': 'noval',
                           'field': 'data.properties.id',
-                          'type': 'zip'#,
+                          'type': 'zip'
                           # 'with': 'table',
                           # 'withKey': 'x'
                       },

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -190,14 +190,15 @@ def assert_grammar_typechecking(grammar_types, test_obj):
         pass
 
     for name, objects in grammar_types:
+        bad_obj = BadType()
         for obj in objects:
             tmp_obj = obj()
             setattr(test_obj, name, tmp_obj)
             nt.assert_equal(getattr(test_obj, name), tmp_obj)
-            bad_obj = BadType()
-            nt.assert_raises_regexp(ValueError, name + '.*' + obj.__name__,
-                                    setattr, test_obj, name, bad_obj)
-            nt.assert_equal(getattr(test_obj, name), tmp_obj)
+            if obj.__name__ != 'str' and obj.__name__ != 'bool':   # any object can have 'str' and 'bool' representations
+                nt.assert_raises_regexp(ValueError, name + '.*' + obj.__name__,
+                                        setattr, test_obj, name, bad_obj)
+                nt.assert_equal(getattr(test_obj, name), tmp_obj)
 
 
 def assert_manual_typechecking(bad_grammar, test_obj):
@@ -618,7 +619,7 @@ class TestTransform(object):
         """Transform field typechecking"""
         grammar_types = [
             ('fields', [list]), ('from_', [str]),
-            ('as_', [list]), ('keys', [list]), ('sort', [str]),
+            ('as_', [list]), ('groupby', [list]), ('sort', [bool, list]),
             ('test', [str]), ('field', [str]), ('expr', [str]),
             ('by', [str, list]), ('value', [str]), ('median', [bool]),
             ('with_', [str]), ('key', [str]), ('with_key', [str]),

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -195,7 +195,9 @@ def assert_grammar_typechecking(grammar_types, test_obj):
             tmp_obj = obj()
             setattr(test_obj, name, tmp_obj)
             nt.assert_equal(getattr(test_obj, name), tmp_obj)
-            if obj.__name__ != 'str' and obj.__name__ != 'bool':   # any object can have 'str' and 'bool' representations
+
+            # any object can have 'str' and 'bool' representations
+            if obj.__name__ != 'str' and obj.__name__ != 'bool':
                 nt.assert_raises_regexp(ValueError, name + '.*' + obj.__name__,
                                         setattr, test_obj, name, bad_obj)
                 nt.assert_equal(getattr(test_obj, name), tmp_obj)

--- a/vincent/__init__.py
+++ b/vincent/__init__.py
@@ -8,7 +8,8 @@ __all__ = [
     "AxisProperties", "Axis", "initialize_notebook"
 ]
 
-from vincent.charts import (Chart, Bar, Line, Area, Scatter, StackedBar, StackedArea,
+from vincent.charts import (Chart, Bar, Line, Area, Scatter,
+                            StackedBar, StackedArea,
                             GroupedBar, Map, Pie, Word)
 from vincent.visualization import Visualization
 from vincent.data import Data

--- a/vincent/__init__.py
+++ b/vincent/__init__.py
@@ -1,13 +1,4 @@
 # -*- coding: utf-8 -*-
-__all__ = [
-    "Chart", "Bar", "Line", "Area", "Scatter",
-    "StackedBar", "StackedArea", "GroupedBar", "Map", "Pie", "Word",
-    "Visualization", "Data", "Transform",
-    "PropertySet", "ValueRef", "DataRef", "Scale",
-    "MarkProperties", "MarkRef", "Mark",
-    "AxisProperties", "Axis", "initialize_notebook"
-]
-
 from vincent.charts import (Chart, Bar, Line, Area, Scatter,
                             StackedBar, StackedArea,
                             GroupedBar, Map, Pie, Word)
@@ -19,3 +10,12 @@ from vincent.properties import PropertySet
 from vincent.scales import DataRef, Scale
 from vincent.marks import MarkProperties, MarkRef, Mark
 from vincent.axes import AxisProperties, Axis
+
+__all__ = [
+    "Chart", "Bar", "Line", "Area", "Scatter",
+    "StackedBar", "StackedArea", "GroupedBar", "Map", "Pie", "Word",
+    "Visualization", "Data", "Transform",
+    "PropertySet", "ValueRef", "DataRef", "Scale",
+    "MarkProperties", "MarkRef", "Mark",
+    "AxisProperties", "Axis", "initialize_notebook"
+]

--- a/vincent/axes.py
+++ b/vincent/axes.py
@@ -139,14 +139,6 @@ class Axis(GrammarClass):
         referenced area
         """
 
-    @grammar(str_types)
-    def layer(value):
-        pass
-
-    @grammar(bool)
-    def grid(value):
-        pass
-
     @grammar(AxisProperties)
     def properties(value):
         """AxisProperties : Custom styling for ticks and tick labels

--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -97,7 +97,9 @@ class Chart(Visualization):
                 if not data:
                     raise ValueError('The data structure is empty.')
             if isinstance(data, (pd.Series, pd.DataFrame)):
-                self._is_datetime = isinstance(data.index, pd.DatetimeIndex) or data.index.is_type_compatible('date') or data.index.is_type_compatible('datetime')
+                self._is_datetime = isinstance(data.index, pd.DatetimeIndex) or\
+                    data.index.is_type_compatible('date') or\
+                    data.index.is_type_compatible('datetime')
 
             # Using a vincent KeyedList here
             self.data['table'] = (
@@ -375,7 +377,8 @@ class GroupedBar(Chart):
                                          properties=mark_props_text))
 
         mark_group_from = MarkRef(data='table',
-            transform=[Transform(type='facet', groupby=['idx'])])
+                                  transform=[Transform(type='facet',
+                                                       groupby=['idx'])])
 
         mark_group_props = MarkProperties(
             enter=PropertySet(x=ValueRef(scale='x', field='key'),
@@ -478,7 +481,7 @@ class Map(Chart):
                 data_transform = Transform(
                     type='zip', field=key_join,
                     # with_='table',
-                    # with_key='x', 
+                    # with_key='x',
                     as_=['value'], default='noval'
                     )
                 transforms.append(data_transform)

--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -97,8 +97,7 @@ class Chart(Visualization):
                 if not data:
                     raise ValueError('The data structure is empty.')
             if isinstance(data, (pd.Series, pd.DataFrame)):
-                if isinstance(data.index, pd.DatetimeIndex):
-                    self._is_datetime = True
+                self._is_datetime = isinstance(data.index, pd.DatetimeIndex) or data.index.is_type_compatible('date') or data.index.is_type_compatible('datetime')
 
             # Using a vincent KeyedList here
             self.data['table'] = (

--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -476,8 +476,10 @@ class Map(Chart):
                     )
                 key_join = '.'.join(['data', map_key[dat['name']]])
                 data_transform = Transform(
-                    type='zip', key=key_join, with_='table',
-                    with_key='x', as_='value', default='noval'
+                    type='zip', field=key_join,
+                    # with_='table',
+                    # with_key='x', 
+                    as_=['value'], default='noval'
                     )
                 transforms.append(data_transform)
                 null_trans = Transform(
@@ -563,7 +565,7 @@ class Pie(Chart):
             domain=DataRef(data="table", field="idx"))
 
         transform = MarkRef(
-            data="table", transform=[Transform(type="pie", value="val")])
+            data="table", transform=[Transform(type="pie", field="val")])
 
         enter_props = PropertySet(
             x=ValueRef(group="width", mult=0.5),

--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -97,7 +97,8 @@ class Chart(Visualization):
                 if not data:
                     raise ValueError('The data structure is empty.')
             if isinstance(data, (pd.Series, pd.DataFrame)):
-                self._is_datetime = isinstance(data.index, pd.DatetimeIndex) or\
+                self._is_datetime = isinstance(data.index,
+                                               pd.DatetimeIndex) or\
                     data.index.is_type_compatible('date') or\
                     data.index.is_type_compatible('datetime')
 

--- a/vincent/charts.py
+++ b/vincent/charts.py
@@ -488,7 +488,7 @@ class Map(Chart):
                 get_brewer = False
 
             geo_transform = Transform(
-                type='geopath', value="data", **geo_kwargs
+                type='geopath', field="data", **geo_kwargs
                 )
             transforms.append(geo_transform)
             self.data[dat['name']] = Data(

--- a/vincent/core.py
+++ b/vincent/core.py
@@ -8,8 +8,7 @@ from __future__ import (print_function, division)
 
 import json
 
-from jinja2 import Template, Environment, PackageLoader, escape
-from pkg_resources import resource_string
+from jinja2 import Environment, PackageLoader
 
 try:
     import pandas as pd
@@ -28,12 +27,13 @@ TMPL_ENV = Environment(loader=PackageLoader('vincent', 'templates'))
 
 def _get_tuple_type_names(tuple_type):
     if type(tuple_type) is tuple:
-        type_names = ', '.join(_get_tuple_type_names(t) for t in tuple_type)   # tuple may contain other tuples
+        # tuple may contain other tuples
+        type_names = ', '.join(_get_tuple_type_names(t) for t in tuple_type)
         return '({0})'.format(type_names)
     else:
         return tuple_type.__name__
 
-        
+
 def _assert_is_type(name, value, value_type):
     """Assert that a value must be a given type."""
     if not isinstance(value, value_type):
@@ -41,7 +41,8 @@ def _assert_is_type(name, value, value_type):
             types = _get_tuple_type_names(value_type)
             raise ValueError('{0} must be one of {1}'.format(name, types))
         else:
-            raise ValueError('{0} must be {1}'.format(name, value_type.__name__))
+            raise ValueError('{0} must be {1}'.format(name,
+                                                      value_type.__name__))
 
 
 class ValidationError(Exception):

--- a/vincent/core.py
+++ b/vincent/core.py
@@ -25,15 +25,23 @@ from vincent._compat import str_types
 
 TMPL_ENV = Environment(loader=PackageLoader('vincent', 'templates'))
 
+
+def _get_tuple_type_names(tuple_type):
+    if type(tuple_type) is tuple:
+        type_names = ', '.join(_get_tuple_type_names(t) for t in tuple_type)   # tuple may contain other tuples
+        return '({0})'.format(type_names)
+    else:
+        return tuple_type.__name__
+
+        
 def _assert_is_type(name, value, value_type):
     """Assert that a value must be a given type."""
     if not isinstance(value, value_type):
         if type(value_type) is tuple:
-            types = ', '.join(t.__name__ for t in value_type)
-            raise ValueError('{0} must be one of ({1})'.format(name, types))
+            types = _get_tuple_type_names(value_type)
+            raise ValueError('{0} must be one of {1}'.format(name, types))
         else:
-            raise ValueError('{0} must be {1}'
-                             .format(name, value_type.__name__))
+            raise ValueError('{0} must be {1}'.format(name, value_type.__name__))
 
 
 class ValidationError(Exception):

--- a/vincent/data.py
+++ b/vincent/data.py
@@ -147,8 +147,8 @@ class Data(GrammarClass):
         elif hasattr(obj, '__int__'):
             return int(obj)
         else:
-            raise LoadError('cannot serialize index of type '
-                            + type(obj).__name__)
+            raise LoadError('cannot serialize index of type ' +
+                            type(obj).__name__)
 
     @classmethod
     def from_pandas(cls, data, columns=None, key_on='idx', name=None,
@@ -229,8 +229,8 @@ class Data(GrammarClass):
                         value['group'] = num
                     vega_data.values.append(value)
         else:
-            raise ValueError('cannot load from data type '
-                             + type(pd_obj).__name__)
+            raise ValueError('cannot load from data type ' +
+                             type(pd_obj).__name__)
         return vega_data
 
     @classmethod

--- a/vincent/properties.py
+++ b/vincent/properties.py
@@ -36,7 +36,7 @@ class PropertySet(GrammarClass):
 
     @grammar(ValueRef)
     def y(value):
-       pass
+        pass
 
     @grammar(ValueRef)
     def y2(value):

--- a/vincent/transforms.py
+++ b/vincent/transforms.py
@@ -363,7 +363,7 @@ class Transform(GrammarClass):
     def scale(value):
         pass
 
-    @grammar((int, str_types))
+    @grammar((int, dict))
     def rotate(value):
         pass
 
@@ -417,7 +417,7 @@ class Transform(GrammarClass):
     def end_angle(value):
         pass
 
-    @grammar(bool)
+    @grammar((bool, list))
     def sort(value):
         pass
 

--- a/vincent/transforms.py
+++ b/vincent/transforms.py
@@ -22,7 +22,7 @@ class AggregateSpec(GrammarClass):
     @grammar(list)
     def ops(value):
 
-        valid_aggregate_ops  = frozenset([
+        valid_aggregate_ops = frozenset([
             "values",
             "count",
             "valid",
@@ -254,10 +254,6 @@ class Transform(GrammarClass):
 
     @grammar(list)
     def keys(value):
-        pass
-
-    @grammar(list, grammar_name="as")
-    def as_(value):
         pass
 
     @grammar(str_types)

--- a/vincent/visualization.py
+++ b/vincent/visualization.py
@@ -6,9 +6,7 @@ Visualization: Top level class for Vega Grammar
 """
 from __future__ import (print_function, division)
 
-from uuid import uuid4
-
-from jinja2 import Template, Environment, PackageLoader, escape
+from jinja2 import Environment, PackageLoader
 
 from vincent.core import (_assert_is_type, ValidationError,
                           KeyedList, grammar, GrammarClass)


### PR DESCRIPTION
There are cases when a dataframe has a regular Index (not DatetimeIndex)
with elements of type 'date' or 'datetime'.  In these cases Vincent
should use the 'time' scale.
